### PR TITLE
Adds support hint flag for indexes

### DIFF
--- a/spacer/init.lua
+++ b/spacer/init.lua
@@ -462,7 +462,11 @@ local function new_spacer(user_opts)
         down_migration_fail_on_impossible = {
             required = false,
             default = true
-        }
+        },
+        hints_enabled = {
+            required = false,
+            default = nil,
+        },
     }
 
     local opts = {}

--- a/spacer/migration.lua
+++ b/spacer/migration.lua
@@ -242,6 +242,15 @@ local function indexes_migration(spacer, space_name, indexes, f, f_extra, check_
         end
         ind_opts.if_not_exists = ind.if_not_exists
         ind_opts.sequence = ind.sequence
+        ind_opts.hint = ind.hint
+
+        if ind_opts.hint == nil then
+            ind_opts.hint = spacer.hints_enabled
+        end
+
+        if ind_opts.hint ~= nil and type(ind_opts.hint) ~= 'boolean' then
+            return error("hint for indexes must be boolean or nil")
+        end
 
         if ind_opts.type == "rtree" then
             if ind.dimension ~= nil then


### PR DESCRIPTION
Since version 2.6.1 Tarantool supports hint option for indexes.

If hints enabled (default) it fasters index but takes x2 RAM.
In some cases RAM is much more expensive and this speed up is not necessary